### PR TITLE
Change Makefile registry name to openbao

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REGISTRY_NAME ?= docker.io/hashicorp
+REGISTRY_NAME ?= docker.io/openbao
 IMAGE_NAME = openbao-k8s
 VERSION ?= 0.0.0-dev
 OPENBAO_VERSION ?= 1.16.1


### PR DESCRIPTION
The test workflow is failing because the build target of the [makefile](https://github.com/openbao/openbao-k8s/blob/main/Makefile#L53) creates an incorrect tag (hashicorp/openbao-k8s).