### PR TITLE
fix(agent-injector): refactor environment variables and flags

### DIFF
--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -17,9 +17,9 @@ import (
 )
 
 const (
-	DefaultOpenbaoImage                       = "openbao/openbao:1.16.1"
-	DefaultOpenbaoAuthType                    = "kubernetes"
-	DefaultOpenbaoAuthPath                    = "auth/kubernetes"
+	DefaultBaoImage                         = "openbao/openbao:1.16.1"
+	DefaultBaoAuthType                      = "kubernetes"
+	DefaultBaoAuthPath                      = "auth/kubernetes"
 	DefaultAgentRunAsUser                   = 100
 	DefaultAgentRunAsGroup                  = 1000
 	DefaultAgentRunAsSameUser               = false
@@ -742,7 +742,7 @@ func (a *Agent) Validate() error {
 			return errors.New("no Openbao Auth Type found")
 		}
 
-		if a.Openbao.AuthType == DefaultOpenbaoAuthType &&
+		if a.Openbao.AuthType == DefaultBaoAuthType &&
 			a.Openbao.Role == "" && a.Annotations[fmt.Sprintf("%s-role", AnnotationOpenbaoAuthConfig)] == "" {
 			return errors.New("no Openbao role found")
 		}

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -390,7 +390,7 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationOpenbaoAuthType]; !ok {
 		if cfg.AuthType == "" {
-			cfg.AuthType = DefaultOpenbaoAuthType
+			cfg.AuthType = DefaultBaoAuthType
 		}
 		pod.ObjectMeta.Annotations[AnnotationOpenbaoAuthType] = cfg.AuthType
 	}
@@ -409,7 +409,7 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentImage]; !ok {
 		if cfg.Image == "" {
-			cfg.Image = DefaultOpenbaoImage
+			cfg.Image = DefaultBaoImage
 		}
 		pod.ObjectMeta.Annotations[AnnotationAgentImage] = cfg.Image
 	}

--- a/agent-inject/agent/annotations_test.go
+++ b/agent-inject/agent/annotations_test.go
@@ -25,7 +25,7 @@ func basicAgentConfig() AgentConfig {
 	return AgentConfig{
 		Image:              "foobar-image",
 		Address:            "http://foobar:8200",
-		AuthType:           DefaultOpenbaoAuthType,
+		AuthType:           DefaultBaoAuthType,
 		AuthPath:           "test",
 		Namespace:          "test",
 		RevokeOnShutdown:   true,
@@ -95,7 +95,7 @@ func TestInitDefaults(t *testing.T) {
 		annotationKey   string
 		annotationValue string
 	}{
-		{annotationKey: AnnotationAgentImage, annotationValue: DefaultOpenbaoImage},
+		{annotationKey: AnnotationAgentImage, annotationValue: DefaultBaoImage},
 		{annotationKey: AnnotationAgentRunAsUser, annotationValue: strconv.Itoa(DefaultAgentRunAsUser)},
 		{annotationKey: AnnotationAgentRunAsGroup, annotationValue: strconv.Itoa(DefaultAgentRunAsGroup)},
 		{annotationKey: AnnotationAgentShareProcessNamespace, annotationValue: ""},

--- a/agent-inject/agent/container_env.go
+++ b/agent-inject/agent/container_env.go
@@ -51,28 +51,28 @@ func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 
 	if a.Openbao.ClientTimeout != "" {
 		envs = append(envs, corev1.EnvVar{
-			Name:  "OPENBAO_CLIENT_TIMEOUT",
+			Name:  "BAO_CLIENT_TIMEOUT",
 			Value: a.Openbao.ClientTimeout,
 		})
 	}
 
 	if a.Openbao.ClientMaxRetries != "" {
 		envs = append(envs, corev1.EnvVar{
-			Name:  "OPENBAO_MAX_RETRIES",
+			Name:  "BAO_MAX_RETRIES",
 			Value: a.Openbao.ClientMaxRetries,
 		})
 	}
 
 	if a.Openbao.LogLevel != "" {
 		envs = append(envs, corev1.EnvVar{
-			Name:  "OPENBAO_LOG_LEVEL",
+			Name:  "BAO_LOG_LEVEL",
 			Value: a.Openbao.LogLevel,
 		})
 	}
 
 	if a.Openbao.LogFormat != "" {
 		envs = append(envs, corev1.EnvVar{
-			Name:  "OPENBAO_LOG_FORMAT",
+			Name:  "BAO_LOG_FORMAT",
 			Value: a.Openbao.LogFormat,
 		})
 	}
@@ -92,48 +92,48 @@ func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 
 		b64Config := base64.StdEncoding.EncodeToString(config)
 		envs = append(envs, corev1.EnvVar{
-			Name:  "OPENBAO_CONFIG",
+			Name:  "BAO_CONFIG",
 			Value: b64Config,
 		})
 	} else {
 		// set up environment variables to access Openbao since "openbao" section may not be present in the config
 		if a.Openbao.Address != "" {
 			envs = append(envs, corev1.EnvVar{
-				Name:  "OPENBAO_ADDR",
+				Name:  "BAO_ADDR",
 				Value: a.Openbao.Address,
 			})
 		}
 		if a.Openbao.CACert != "" {
 			envs = append(envs, corev1.EnvVar{
-				Name:  "OPENBAO_CACERT",
+				Name:  "BAO_CACERT",
 				Value: a.Openbao.CACert,
 			})
 		}
 		if a.Openbao.CAKey != "" {
 			envs = append(envs, corev1.EnvVar{
-				Name:  "OPENBAO_CAPATH",
+				Name:  "BAO_CAPATH",
 				Value: a.Openbao.CAKey,
 			})
 		}
 		if a.Openbao.ClientCert != "" {
 			envs = append(envs, corev1.EnvVar{
-				Name:  "OPENBAO_CLIENT_CERT",
+				Name:  "BAO_CLIENT_CERT",
 				Value: a.Openbao.ClientCert,
 			})
 		}
 		if a.Openbao.ClientKey != "" {
 			envs = append(envs, corev1.EnvVar{
-				Name:  "OPENBAO_CLIENT_KEY",
+				Name:  "BAO_CLIENT_KEY",
 				Value: a.Openbao.ClientKey,
 			})
 		}
 		envs = append(envs, corev1.EnvVar{
-			Name:  "OPENBAO_SKIP_VERIFY",
+			Name:  "BAO_SKIP_VERIFY",
 			Value: strconv.FormatBool(a.Openbao.TLSSkipVerify),
 		})
 		if a.Openbao.TLSServerName != "" {
 			envs = append(envs, corev1.EnvVar{
-				Name:  "OPENBAO_TLS_SERVER_NAME",
+				Name:  "BAO_TLS_SERVER_NAME",
 				Value: a.Openbao.TLSServerName,
 			})
 		}
@@ -141,7 +141,7 @@ func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 
 	if a.Openbao.CACertBytes != "" {
 		envs = append(envs, corev1.EnvVar{
-			Name:  "OPENBAO_CACERT_BYTES",
+			Name:  "BAO_CACERT_BYTES",
 			Value: decodeIfBase64(a.Openbao.CACertBytes),
 		})
 	}

--- a/agent-inject/agent/container_env_test.go
+++ b/agent-inject/agent/container_env_test.go
@@ -19,13 +19,13 @@ func TestContainerEnvs(t *testing.T) {
 		agent        Agent
 		expectedEnvs []string
 	}{
-		{Agent{}, append(baseEnvVars, "OPENBAO_CONFIG")},
-		{Agent{Openbao: Openbao{Address: "http://localhost:8200"}, ConfigMapName: "foobar"}, append(baseEnvVars, "OPENBAO_SKIP_VERIFY", "OPENBAO_ADDR")},
-		{Agent{Openbao: Openbao{ClientMaxRetries: "0"}}, append(baseEnvVars, "OPENBAO_CONFIG", "OPENBAO_MAX_RETRIES")},
-		{Agent{Openbao: Openbao{ClientTimeout: "5s"}}, append(baseEnvVars, "OPENBAO_CONFIG", "OPENBAO_CLIENT_TIMEOUT")},
-		{Agent{Openbao: Openbao{ClientMaxRetries: "0", ClientTimeout: "5s"}}, append(baseEnvVars, "OPENBAO_CONFIG", "OPENBAO_MAX_RETRIES", "OPENBAO_CLIENT_TIMEOUT")},
-		{Agent{ConfigMapName: "foobar", Openbao: Openbao{Address: "http://localhost:8200", ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info", ProxyAddress: "http://proxy:3128"}}, append(baseEnvVars, "OPENBAO_MAX_RETRIES", "OPENBAO_CLIENT_TIMEOUT", "OPENBAO_LOG_LEVEL", "HTTPS_PROXY", "OPENBAO_SKIP_VERIFY", "OPENBAO_ADDR")},
-		{Agent{Openbao: Openbao{GoMaxProcs: "1"}}, append(baseEnvVars, "OPENBAO_CONFIG", "GOMAXPROCS")},
+		{Agent{}, append(baseEnvVars, "BAO_CONFIG")},
+		{Agent{Openbao: Openbao{Address: "http://localhost:8200"}, ConfigMapName: "foobar"}, append(baseEnvVars, "BAO_SKIP_VERIFY", "BAO_ADDR")},
+		{Agent{Openbao: Openbao{ClientMaxRetries: "0"}}, append(baseEnvVars, "BAO_CONFIG", "BAO_MAX_RETRIES")},
+		{Agent{Openbao: Openbao{ClientTimeout: "5s"}}, append(baseEnvVars, "BAO_CONFIG", "BAO_CLIENT_TIMEOUT")},
+		{Agent{Openbao: Openbao{ClientMaxRetries: "0", ClientTimeout: "5s"}}, append(baseEnvVars, "BAO_CONFIG", "BAO_MAX_RETRIES", "BAO_CLIENT_TIMEOUT")},
+		{Agent{ConfigMapName: "foobar", Openbao: Openbao{Address: "http://localhost:8200", ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info", ProxyAddress: "http://proxy:3128"}}, append(baseEnvVars, "BAO_MAX_RETRIES", "BAO_CLIENT_TIMEOUT", "BAO_LOG_LEVEL", "HTTPS_PROXY", "BAO_SKIP_VERIFY", "BAO_ADDR")},
+		{Agent{Openbao: Openbao{GoMaxProcs: "1"}}, append(baseEnvVars, "BAO_CONFIG", "GOMAXPROCS")},
 	}
 
 	for _, tt := range tests {
@@ -50,9 +50,9 @@ func TestContainerEnvsForIRSA(t *testing.T) {
 		agent        Agent
 		expectedEnvs []string
 	}{
-		{Agent{Pod: testPodWithoutIRSA()}, append(baseEnvVars, "OPENBAO_CONFIG")},
+		{Agent{Pod: testPodWithoutIRSA()}, append(baseEnvVars, "BAO_CONFIG")},
 		{Agent{Pod: testPodWithIRSA(), Openbao: Openbao{AuthType: "aws"}},
-			append(baseEnvVars, "OPENBAO_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_DEFAULT_REGION", "AWS_REGION"),
+			append(baseEnvVars, "BAO_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_DEFAULT_REGION", "AWS_REGION"),
 		},
 	}
 	for _, tt := range envTests {
@@ -72,10 +72,10 @@ func TestAwsRegionEnvForAwsAuthMethod(t *testing.T) {
 		expectedEnvs []string
 	}{
 		{Agent{Pod: testPodWithRegionInAuthConfig(), Openbao: Openbao{AuthType: "aws", AuthConfig: getRegionMap()}},
-			append(baseEnvVars, "OPENBAO_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_REGION"),
+			append(baseEnvVars, "BAO_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_REGION"),
 		},
 		{Agent{Pod: testPodWithIRSA(), Openbao: Openbao{AuthType: "aws"}},
-			append(baseEnvVars, "OPENBAO_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_DEFAULT_REGION", "AWS_REGION"),
+			append(baseEnvVars, "BAO_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_DEFAULT_REGION", "AWS_REGION"),
 		},
 	}
 	for _, item := range input {

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -20,7 +20,7 @@ const (
 	DefaultResourceLimitMem   = "128Mi"
 	DefaultResourceRequestCPU = "250m"
 	DefaultResourceRequestMem = "64Mi"
-	DefaultContainerArg       = "echo ${OPENBAO_CONFIG?} | base64 -d > /home/openbao/config.json && bao agent -config=/home/openbao/config.json"
+	DefaultContainerArg       = "echo ${BAO_CONFIG?} | base64 -d > /home/openbao/config.json && bao agent -config=/home/openbao/config.json"
 	DefaultRevokeGrace        = 5
 	DefaultAgentLogLevel      = "info"
 	DefaultAgentLogFormat     = "standard"

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -48,7 +48,7 @@ func TestContainerSidecarVolume(t *testing.T) {
 	agentConfig := AgentConfig{
 		Image:              "foobar-image",
 		Address:            "http://foobar:1234",
-		AuthType:           DefaultOpenbaoAuthType,
+		AuthType:           DefaultBaoAuthType,
 		AuthPath:           "test",
 		Namespace:          "test",
 		RevokeOnShutdown:   true,
@@ -217,7 +217,7 @@ func TestContainerSidecar(t *testing.T) {
 	agentConfig := AgentConfig{
 		Image:              "foobar-image",
 		Address:            "http://foobar:1234",
-		AuthType:           DefaultOpenbaoAuthType,
+		AuthType:           DefaultBaoAuthType,
 		AuthPath:           "test",
 		Namespace:          "test",
 		UserID:             "1000",
@@ -253,16 +253,16 @@ func TestContainerSidecar(t *testing.T) {
 		t.Errorf("wrong number of env vars, got %d, should have been %d", len(container.Env), expectedEnvs)
 	}
 
-	if container.Env[3].Name != "OPENBAO_LOG_LEVEL" {
-		t.Errorf("env name wrong, should have been %s, got %s", "OPENBAO_LOG_LEVEL", container.Env[0].Name)
+	if container.Env[3].Name != "BAO_LOG_LEVEL" {
+		t.Errorf("env name wrong, should have been %s, got %s", "BAO_LOG_LEVEL", container.Env[0].Name)
 	}
 
 	if container.Env[3].Value == "" {
 		t.Error("env value empty, it shouldn't be")
 	}
 
-	if container.Env[4].Name != "OPENBAO_LOG_FORMAT" {
-		t.Errorf("env name wrong, should have been %s, got %s", "OPENBAO_LOG_FORMAT", container.Env[1].Name)
+	if container.Env[4].Name != "BAO_LOG_FORMAT" {
+		t.Errorf("env name wrong, should have been %s, got %s", "BAO_LOG_FORMAT", container.Env[1].Name)
 	}
 
 	if container.Env[5].Name != "HTTPS_PROXY" {
@@ -273,8 +273,8 @@ func TestContainerSidecar(t *testing.T) {
 		t.Error("env value empty, it shouldn't be")
 	}
 
-	if container.Env[6].Name != "OPENBAO_CONFIG" {
-		t.Errorf("env name wrong, should have been %s, got %s", "OPENBAO_CONFIG", container.Env[3].Name)
+	if container.Env[6].Name != "BAO_CONFIG" {
+		t.Errorf("env name wrong, should have been %s, got %s", "BAO_CONFIG", container.Env[3].Name)
 	}
 
 	if container.Env[5].Value == "" {
@@ -356,7 +356,7 @@ func TestContainerSidecarRevokeHook(t *testing.T) {
 			agentConfig := AgentConfig{
 				Image:              "foobar-image",
 				Address:            "http://foobar:1234",
-				AuthType:           DefaultOpenbaoAuthType,
+				AuthType:           DefaultBaoAuthType,
 				AuthPath:           "test",
 				Namespace:          "test",
 				RevokeOnShutdown:   tt.revokeFlag,
@@ -423,7 +423,7 @@ func TestContainerSidecarConfigMap(t *testing.T) {
 	agentConfig := AgentConfig{
 		Image:              "foobar-image",
 		Address:            "http://foobar:1234",
-		AuthType:           DefaultOpenbaoAuthType,
+		AuthType:           DefaultBaoAuthType,
 		AuthPath:           "test",
 		Namespace:          "test",
 		RevokeOnShutdown:   true,
@@ -1231,7 +1231,7 @@ func TestContainerCache(t *testing.T) {
 			agentConfig := AgentConfig{
 				Image:              "foobar-image",
 				Address:            "http://foobar:1234",
-				AuthType:           DefaultOpenbaoAuthType,
+				AuthType:           DefaultBaoAuthType,
 				AuthPath:           "test",
 				Namespace:          "test",
 				RevokeOnShutdown:   true,
@@ -1284,12 +1284,12 @@ func TestAgentJsonPatch(t *testing.T) {
 		Name:    "openbao-agent",
 		Image:   "foobar-image",
 		Command: []string{"/bin/sh", "-ec"},
-		Args:    []string{`echo ${OPENBAO_CONFIG?} | base64 -d > /home/openbao/config.json && bao agent -config=/home/openbao/config.json`},
+		Args:    []string{`echo ${BAO_CONFIG?} | base64 -d > /home/openbao/config.json && bao agent -config=/home/openbao/config.json`},
 		Env: append(
 			baseContainerEnvVars,
-			corev1.EnvVar{Name: "OPENBAO_LOG_LEVEL", Value: "info"},
-			corev1.EnvVar{Name: "OPENBAO_LOG_FORMAT", Value: "standard"},
-			corev1.EnvVar{Name: "OPENBAO_CONFIG", Value: "eyJhdXRvX2F1dGgiOnsibWV0aG9kIjp7InR5cGUiOiJrdWJlcm5ldGVzIiwibW91bnRfcGF0aCI6InRlc3QiLCJjb25maWciOnsicm9sZSI6InJvbGUiLCJ0b2tlbl9wYXRoIjoic2VydmljZWFjY291bnQvc29tZXdoZXJlL3Rva2VuIn19LCJzaW5rIjpbeyJ0eXBlIjoiZmlsZSIsImNvbmZpZyI6eyJwYXRoIjoiL2hvbWUvb3BlbmJhby8ub3BlbmJhby10b2tlbiJ9fV19LCJleGl0X2FmdGVyX2F1dGgiOmZhbHNlLCJwaWRfZmlsZSI6Ii9ob21lL29wZW5iYW8vLnBpZCIsIm9wZW5iYW8iOnsiYWRkcmVzcyI6Imh0dHA6Ly9mb29iYXI6MTIzNCJ9LCJ0ZW1wbGF0ZV9jb25maWciOnsiZXhpdF9vbl9yZXRyeV9mYWlsdXJlIjp0cnVlfX0="},
+			corev1.EnvVar{Name: "BAO_LOG_LEVEL", Value: "info"},
+			corev1.EnvVar{Name: "BAO_LOG_FORMAT", Value: "standard"},
+			corev1.EnvVar{Name: "BAO_CONFIG", Value: "eyJhdXRvX2F1dGgiOnsibWV0aG9kIjp7InR5cGUiOiJrdWJlcm5ldGVzIiwibW91bnRfcGF0aCI6InRlc3QiLCJjb25maWciOnsicm9sZSI6InJvbGUiLCJ0b2tlbl9wYXRoIjoic2VydmljZWFjY291bnQvc29tZXdoZXJlL3Rva2VuIn19LCJzaW5rIjpbeyJ0eXBlIjoiZmlsZSIsImNvbmZpZyI6eyJwYXRoIjoiL2hvbWUvb3BlbmJhby8ub3BlbmJhby10b2tlbiJ9fV19LCJleGl0X2FmdGVyX2F1dGgiOmZhbHNlLCJwaWRfZmlsZSI6Ii9ob21lL29wZW5iYW8vLnBpZCIsIm9wZW5iYW8iOnsiYWRkcmVzcyI6Imh0dHA6Ly9mb29iYXI6MTIzNCJ9LCJ0ZW1wbGF0ZV9jb25maWciOnsiZXhpdF9vbl9yZXRyeV9mYWlsdXJlIjp0cnVlfX0="},
 		),
 		Resources: v1.ResourceRequirements{
 			Limits:   v1.ResourceList{"cpu": resource.MustParse("500m"), "memory": resource.MustParse("128Mi")},
@@ -1323,9 +1323,9 @@ func TestAgentJsonPatch(t *testing.T) {
 	baseInitContainer.Name = "openbao-agent-init"
 	baseInitContainer.Env = append(
 		baseContainerEnvVars,
-		corev1.EnvVar{Name: "OPENBAO_LOG_LEVEL", Value: "info"},
-		corev1.EnvVar{Name: "OPENBAO_LOG_FORMAT", Value: "standard"},
-		corev1.EnvVar{Name: "OPENBAO_CONFIG", Value: "eyJhdXRvX2F1dGgiOnsibWV0aG9kIjp7InR5cGUiOiJrdWJlcm5ldGVzIiwibW91bnRfcGF0aCI6InRlc3QiLCJjb25maWciOnsicm9sZSI6InJvbGUiLCJ0b2tlbl9wYXRoIjoic2VydmljZWFjY291bnQvc29tZXdoZXJlL3Rva2VuIn19LCJzaW5rIjpbeyJ0eXBlIjoiZmlsZSIsImNvbmZpZyI6eyJwYXRoIjoiL2hvbWUvb3BlbmJhby8ub3BlbmJhby10b2tlbiJ9fV19LCJleGl0X2FmdGVyX2F1dGgiOnRydWUsInBpZF9maWxlIjoiL2hvbWUvb3BlbmJhby8ucGlkIiwib3BlbmJhbyI6eyJhZGRyZXNzIjoiaHR0cDovL2Zvb2JhcjoxMjM0In0sInRlbXBsYXRlX2NvbmZpZyI6eyJleGl0X29uX3JldHJ5X2ZhaWx1cmUiOnRydWV9fQ=="},
+		corev1.EnvVar{Name: "BAO_LOG_LEVEL", Value: "info"},
+		corev1.EnvVar{Name: "BAO_LOG_FORMAT", Value: "standard"},
+		corev1.EnvVar{Name: "BAO_CONFIG", Value: "eyJhdXRvX2F1dGgiOnsibWV0aG9kIjp7InR5cGUiOiJrdWJlcm5ldGVzIiwibW91bnRfcGF0aCI6InRlc3QiLCJjb25maWciOnsicm9sZSI6InJvbGUiLCJ0b2tlbl9wYXRoIjoic2VydmljZWFjY291bnQvc29tZXdoZXJlL3Rva2VuIn19LCJzaW5rIjpbeyJ0eXBlIjoiZmlsZSIsImNvbmZpZyI6eyJwYXRoIjoiL2hvbWUvb3BlbmJhby8ub3BlbmJhby10b2tlbiJ9fV19LCJleGl0X2FmdGVyX2F1dGgiOnRydWUsInBpZF9maWxlIjoiL2hvbWUvb3BlbmJhby8ucGlkIiwib3BlbmJhbyI6eyJhZGRyZXNzIjoiaHR0cDovL2Zvb2JhcjoxMjM0In0sInRlbXBsYXRlX2NvbmZpZyI6eyJleGl0X29uX3JldHJ5X2ZhaWx1cmUiOnRydWV9fQ=="},
 	)
 	baseInitContainer.VolumeMounts = []v1.VolumeMount{
 		{Name: "home-init", MountPath: "/home/openbao"},
@@ -1423,7 +1423,7 @@ func TestAgentJsonPatch(t *testing.T) {
 			agentConfig := AgentConfig{
 				Image:              "foobar-image",
 				Address:            "http://foobar:1234",
-				AuthType:           DefaultOpenbaoAuthType,
+				AuthType:           DefaultBaoAuthType,
 				AuthPath:           "test",
 				Namespace:          "test",
 				RevokeOnShutdown:   true,

--- a/deploy/injector-deployment.yaml
+++ b/deploy/injector-deployment.yaml
@@ -41,9 +41,9 @@ spec:
               value: "info"
             - name: AGENT_INJECT_LOG_FORMAT
               value: "standard"
-            - name: AGENT_INJECT_OPENBAO_ADDR
+            - name: AGENT_INJECT_BAO_ADDR
               value: "https://openbao.$(NAMESPACE).svc:8200"
-            - name: AGENT_INJECT_OPENBAO_IMAGE
+            - name: AGENT_INJECT_BAO_IMAGE
               value: "openbao/openbao:1.16.1"
             - name: AGENT_INJECT_TLS_AUTO
               value: openbao-agent-injector-cfg

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -54,13 +54,13 @@ type Command struct {
 	flagMaxConnectionsPerHost      int64  // Set template_config.max_connections_per_host on agent
 	flagAutoName                   string // MutatingWebhookConfiguration for updating
 	flagAutoHosts                  string // SANs for the auto-generated TLS cert.
-	flagOpenbaoService               string // Name of the Openbao service
-	flagOpenbaoCACertBytes           string // CA Cert to trust for TLS with Openbao.
+	flagBaoService                 string // Name of the Openbao service
+	flagBaoCACertBytes             string // CA Cert to trust for TLS with Openbao.
 	flagProxyAddress               string // HTTP proxy address used to talk to the Openbao service
-	flagOpenbaoImage                 string // Name of the Openbao Image to use
-	flagOpenbaoAuthType              string // Type of Openbao Auth Method to use
-	flagOpenbaoAuthPath              string // Mount path of the Openbao Auth Method
-	flagOpenbaoNamespace             string // Openbao enterprise namespace
+	flagBaoImage                   string // Name of the Openbao Image to use
+	flagBaoAuthType                string // Type of Openbao Auth Method to use
+	flagBaoAuthPath                string // Mount path of the Openbao Auth Method
+	flagBaoNamespace               string // Openbao enterprise namespace
 	flagRevokeOnShutdown           bool   // Revoke Openbao Token on pod shutdown
 	flagRunAsUser                  string // User (uid) to run Openbao agent as
 	flagRunAsGroup                 string // Group (gid) to run Openbao agent as
@@ -103,7 +103,7 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	if c.flagOpenbaoService == "" {
+	if c.flagBaoService == "" {
 		c.UI.Error("No Openbao service configured")
 		return 1
 	}
@@ -194,13 +194,13 @@ func (c *Command) Run(args []string) int {
 
 	// Build the HTTP handler and server
 	injector := agentInject.Handler{
-		OpenbaoAddress:               c.flagOpenbaoService,
-		OpenbaoCACertBytes:           c.flagOpenbaoCACertBytes,
-		OpenbaoAuthType:              c.flagOpenbaoAuthType,
-		OpenbaoAuthPath:              c.flagOpenbaoAuthPath,
-		OpenbaoNamespace:             c.flagOpenbaoNamespace,
+		OpenbaoAddress:             c.flagBaoService,
+		OpenbaoCACertBytes:         c.flagBaoCACertBytes,
+		OpenbaoAuthType:            c.flagBaoAuthType,
+		OpenbaoAuthPath:            c.flagBaoAuthPath,
+		OpenbaoNamespace:           c.flagBaoNamespace,
 		ProxyAddress:               c.flagProxyAddress,
-		ImageOpenbao:                 c.flagOpenbaoImage,
+		ImageOpenbao:               c.flagBaoImage,
 		Clientset:                  clientset,
 		RequireAnnotation:          true,
 		Log:                        logger,

--- a/subcommand/injector/env.go
+++ b/subcommand/injector/env.go
@@ -1,0 +1,22 @@
+// Copyright The OpenBao Contributors
+// SPDX-License-Identifier: MPL-2.0
+
+package agent
+
+import (
+	"os"
+	"strings"
+)
+
+func ReadBaoVariable(name string) string {
+	nonPrefixedName := strings.Replace(name, "AGENT_INJECT_BAO_", "", 1)
+	prefixes := [2]string{"AGENT_INJECT_BAO_", "AGENT_INJECT_VAULT_"}
+	for _, prefix := range prefixes {
+		searchName := prefix + nonPrefixedName
+		result := os.Getenv(searchName)
+		if result != "" {
+			return result
+		}
+	}
+	return ""
+}

--- a/subcommand/injector/env_test.go
+++ b/subcommand/injector/env_test.go
@@ -1,0 +1,32 @@
+// Copyright The OpenBao Contributors
+// SPDX-License-Identifier: MPL-2.0
+
+package agent
+
+import (
+	"os"
+	"testing"
+  	"github.com/stretchr/testify/require"
+)
+
+func TestReadBaoVariable_Vault(t *testing.T) {
+	actual := "example_value"
+	os.Setenv("AGENT_INJECT_VAULT_TEST", actual)
+	expected := ReadBaoVariable("AGENT_INJECT_BAO_TEST")
+	require.Equal(t, actual, expected, "bad: Failed to Read Enviroment Variable actual: %s expected: %s", actual, expected)
+}
+
+func TestReadBaoVariable_Bao(t *testing.T) {
+	actual := "example_value"
+	os.Setenv("AGENT_INJECT_BAO_TEST", actual)
+	expected := ReadBaoVariable("AGENT_INJECT_BAO_TEST")
+	require.Equal(t, actual, expected, "bad: Failed to Read Enviroment Variable actual: %s expected: %s", actual, expected)
+}
+
+func TestReadBaoVariable_BaoWins(t *testing.T) {
+	actual := "example_value"
+	os.Setenv("AGENT_INJECT_VAULT_TEST", actual+"_not_valid")
+	os.Setenv("AGENT_INJECT_BAO_TEST", actual)
+	expected := ReadBaoVariable("AGENT_INJECT_BAO_TEST")
+	require.Equal(t, actual, expected, "bad: Failed to Read Enviroment Variable actual: %s expected: %s", actual, expected)
+}

--- a/subcommand/injector/flags_test.go
+++ b/subcommand/injector/flags_test.go
@@ -115,12 +115,12 @@ func TestCommandEnvs(t *testing.T) {
 		cmdPtr *string
 	}{
 		{env: "AGENT_INJECT_LISTEN", value: ":8080", cmdPtr: &cmd.flagListen},
-		{env: "AGENT_INJECT_OPENBAO_ADDR", value: "http://openbao:8200", cmdPtr: &cmd.flagOpenbaoService},
-		{env: "AGENT_INJECT_OPENBAO_CACERT_BYTES", value: "foo", cmdPtr: &cmd.flagOpenbaoCACertBytes},
+		{env: "AGENT_INJECT_BAO_ADDR", value: "http://openbao:8200", cmdPtr: &cmd.flagBaoService},
+		{env: "AGENT_INJECT_BAO_CACERT_BYTES", value: "foo", cmdPtr: &cmd.flagBaoCACertBytes},
 		{env: "AGENT_INJECT_PROXY_ADDR", value: "http://proxy:3128", cmdPtr: &cmd.flagProxyAddress},
-		{env: "AGENT_INJECT_OPENBAO_AUTH_PATH", value: "auth-path-test", cmdPtr: &cmd.flagOpenbaoAuthPath},
-		{env: "AGENT_INJECT_OPENBAO_IMAGE", value: "openbao/openbao:1.16.1", cmdPtr: &cmd.flagOpenbaoImage},
-		{env: "AGENT_INJECT_OPENBAO_NAMESPACE", value: "test-namespace", cmdPtr: &cmd.flagOpenbaoNamespace},
+		{env: "AGENT_INJECT_BAO_AUTH_PATH", value: "auth-path-test", cmdPtr: &cmd.flagBaoAuthPath},
+		{env: "AGENT_INJECT_BAO_IMAGE", value: "openbao/openbao:1.16.1", cmdPtr: &cmd.flagBaoImage},
+		{env: "AGENT_INJECT_BAO_NAMESPACE", value: "test-namespace", cmdPtr: &cmd.flagBaoNamespace},
 		{env: "AGENT_INJECT_TLS_KEY_FILE", value: "server.key", cmdPtr: &cmd.flagKeyFile},
 		{env: "AGENT_INJECT_TLS_CERT_FILE", value: "server.crt", cmdPtr: &cmd.flagCertFile},
 		{env: "AGENT_INJECT_TLS_AUTO_HOSTS", value: "foobar.com", cmdPtr: &cmd.flagAutoHosts},


### PR DESCRIPTION
This PR changes how environment variables and flags are named.

Environment variables with the prefix `AGENT_INJECT_OPENBAO` can now be set using `AGENT_INJECT_BAO` or `AGENT_INJECT_VAULT`. This is a breaking change, but as we never had a release I don't think its much of an issue.

Flags were also updated to use `bao` instead of `openbao`. These currently only support being set using `bao` and not `vault`. This might be something that could be added in the flag helper maybe?

Currently [envconfig](https://github.com/kelseyhightower/envconfig) is being used for reading env variables, as this lib does not support reading from two different prefixed the 6 ENV variables that include `BAO` are now read using a helper function.

I'm now off for a week, so feel free to review / modify / enhance this PR during my vacation :)