### PR TITLE
chore: point security mailing list in bug report template to new domain

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 <!-- Please reserve GitHub issues for bug reports and feature requests.
 
-Please note: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, _please responsibly disclose_ by contacting us at openbao-security@lists.lfedge.org.
+Please note: We take OpenBao's security and our users' trust very seriously. If you believe you have found a security issue in OpenBao, _please responsibly disclose_ by contacting us at openbao-security@lists.openssf.org.
 
 -->
 


### PR DESCRIPTION
Small chore PR to point another outdated mailing list link to the new OpenSSF domain.

Related to https://github.com/openbao/openbao/issues/1413.