### PR TITLE
fix(agent-inject): revert folders to /vault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ exercise:
 		--annotations="openbao.org/agent-inject-secret-secret.txt=secret/data/test-app" \
 		--overrides='{ "apiVersion": "v1", "spec": { "serviceAccountName": "test-app-sa" } }'
 	kubectl wait --for=condition=Ready --timeout=5m pod nginx
-	kubectl exec nginx -c nginx -- cat /openbao/secrets/secret.txt
+	kubectl exec nginx -c nginx -- cat /vault/secrets/secret.txt
 
 # Teardown any resources created in deploy and exercise targets.
 teardown:

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -166,7 +166,7 @@ type Agent struct {
 	CopyVolumeMounts string
 
 	// InjectToken controls whether the auto-auth token is injected into the
-	// secrets volume (e.g. /openbao/secrets/token)
+	// secrets volume (e.g. /vault/secrets/token)
 	InjectToken bool
 
 	// EnableQuit controls whether the quit endpoint is enabled on a localhost

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -81,7 +81,7 @@ const (
 	AnnotationAgentInjectTemplateFile = "openbao.org/agent-inject-template-file"
 
 	// AnnotationAgentInjectToken is the annotation key for injecting the
-	// auto-auth token into the secrets volume (e.g. /openbao/secrets/token)
+	// auto-auth token into the secrets volume (e.g. /vault/secrets/token)
 	AnnotationAgentInjectToken = "openbao.org/agent-inject-token"
 
 	// AnnotationAgentInjectCommand is the key annotation that configures Openbao Agent

--- a/agent-inject/agent/config_test.go
+++ b/agent-inject/agent/config_test.go
@@ -27,7 +27,7 @@ func TestNewConfig(t *testing.T) {
 		AnnotationOpenbaoCAKey:                            "ca-key",
 		AnnotationOpenbaoClientCert:                       "client-cert",
 		AnnotationOpenbaoClientKey:                        "client-key",
-		AnnotationOpenbaoSecretVolumePath:                 "/openbao/secrets",
+		AnnotationOpenbaoSecretVolumePath:                 "/vault/secrets",
 		AnnotationProxyAddress:                          "http://proxy:3128",
 		"openbao.org/agent-inject-secret-foo":   "db/creds/foo",
 		"openbao.org/agent-inject-template-foo": "template foo",
@@ -127,16 +127,16 @@ func TestNewConfig(t *testing.T) {
 
 	for _, template := range config.Templates {
 		if strings.Contains(template.Destination, "foo") {
-			if template.Destination != "/openbao/secrets/foo" {
-				t.Errorf("expected template destination to be %s, got %s", "/openbao/secrets/foo", template.Destination)
+			if template.Destination != "/vault/secrets/foo" {
+				t.Errorf("expected template destination to be %s, got %s", "/vault/secrets/foo", template.Destination)
 			}
 
 			if template.Contents != "template foo" {
 				t.Errorf("expected template contents to be %s, got %s", "template foo", template.Contents)
 			}
 		} else if strings.Contains(template.Destination, "bar") {
-			if template.Destination != "/openbao/secrets/bar" {
-				t.Errorf("expected template destination to be %s, got %s", "/openbao/secrets/bar", template.Destination)
+			if template.Destination != "/vault/secrets/bar" {
+				t.Errorf("expected template destination to be %s, got %s", "/vault/secrets/bar", template.Destination)
 			}
 
 			if !strings.Contains(template.Contents, "with secret \"db/creds/bar\"") {
@@ -167,8 +167,8 @@ func TestNewConfig(t *testing.T) {
 				t.Errorf("expected template command to be %s, got %s", "/tmp/smth.sh", template.Command)
 			}
 		} else if template.Source == "just-template-file" {
-			if template.Destination != "/openbao/secrets/just-template-file" {
-				t.Errorf("expected template destination to be %s, got %s", "/openbao/secrets/just-template-file", template.Destination)
+			if template.Destination != "/vault/secrets/just-template-file" {
+				t.Errorf("expected template destination to be %s, got %s", "/vault/secrets/just-template-file", template.Destination)
 			}
 		} else {
 			t.Error("shouldn't have got here")
@@ -512,7 +512,7 @@ func TestConfigOpenbaoAgentCache_persistent(t *testing.T) {
 				UseAutoAuthToken: "true",
 				Persist: &CachePersist{
 					Type: "kubernetes",
-					Path: "/openbao/agent-cache",
+					Path: "/vault/agent-cache",
 				},
 			},
 			expectedListeners: []*Listener{
@@ -534,7 +534,7 @@ func TestConfigOpenbaoAgentCache_persistent(t *testing.T) {
 				UseAutoAuthToken: "true",
 				Persist: &CachePersist{
 					Type:      "kubernetes",
-					Path:      "/openbao/agent-cache",
+					Path:      "/vault/agent-cache",
 					ExitOnErr: true,
 				},
 			},
@@ -813,7 +813,7 @@ func TestConfigAgentQuit(t *testing.T) {
 				UseAutoAuthToken: "true",
 				Persist: &CachePersist{
 					Type: "kubernetes",
-					Path: "/openbao/agent-cache",
+					Path: "/vault/agent-cache",
 				},
 			},
 		},
@@ -829,7 +829,7 @@ func TestConfigAgentQuit(t *testing.T) {
 				UseAutoAuthToken: "true",
 				Persist: &CachePersist{
 					Type: "kubernetes",
-					Path: "/openbao/agent-cache",
+					Path: "/vault/agent-cache",
 				},
 			},
 		},

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -1298,7 +1298,7 @@ func TestAgentJsonPatch(t *testing.T) {
 		VolumeMounts: []v1.VolumeMount{
 			{Name: "foobar", ReadOnly: true, MountPath: "serviceaccount/somewhere"},
 			{Name: "home-sidecar", MountPath: "/home/openbao"},
-			{Name: "openbao-secrets", MountPath: "/openbao/secrets"},
+			{Name: "openbao-secrets", MountPath: "/vault/secrets"},
 		},
 		Lifecycle: &v1.Lifecycle{
 			PreStop: &v1.LifecycleHandler{
@@ -1330,7 +1330,7 @@ func TestAgentJsonPatch(t *testing.T) {
 	baseInitContainer.VolumeMounts = []v1.VolumeMount{
 		{Name: "home-init", MountPath: "/home/openbao"},
 		{Name: "foobar", ReadOnly: true, MountPath: "serviceaccount/somewhere"},
-		{Name: "openbao-secrets", MountPath: "/openbao/secrets"},
+		{Name: "openbao-secrets", MountPath: "/vault/secrets"},
 	}
 	baseInitContainer.Lifecycle = nil
 

--- a/agent-inject/agent/container_volume.go
+++ b/agent-inject/agent/container_volume.go
@@ -15,15 +15,15 @@ const (
 	tokenVolumeNameSidecar = "home-sidecar"
 	tokenVolumePath        = "/home/openbao"
 	configVolumeName       = "openbao-config"
-	configVolumePath       = "/openbao/configs"
+	configVolumePath       = "/vault/configs"
 	secretVolumeName       = "openbao-secrets"
 	tlsSecretVolumeName    = "openbao-tls-secrets"
-	tlsSecretVolumePath    = "/openbao/tls"
-	secretVolumePath       = "/openbao/secrets"
+	tlsSecretVolumePath    = "/vault/tls"
+	secretVolumePath       = "/vault/secrets"
 	extraSecretVolumeName  = "extra-secrets"
-	extraSecretVolumePath  = "/openbao/custom"
+	extraSecretVolumePath  = "/vault/custom"
 	cacheVolumeName        = "openbao-agent-cache"
-	cacheVolumePath        = "/openbao/agent-cache"
+	cacheVolumePath        = "/vault/agent-cache"
 )
 
 func (a *Agent) getUniqueMountPaths() []string {


### PR DESCRIPTION
To ensure backwards compability we should save secrets etc into `/vault` instead of `/openbao`.
@openbao/openbao-k8s-committers whats your opinion on this?