### PR TITLE
feat(agent-inject): remove vault.hashicorp.com annotation even when openbao.org annotation is present

### DIFF
--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -187,6 +187,10 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) *admissionv1.Admissi
 					internal.AddOp("/metadata/annotations/"+internal.EscapeJSONPointer(newAnnotation), value),
 					internal.RemoveOp("/metadata/annotations/" + internal.EscapeJSONPointer(annotation)),
 				}...)
+			} else {
+				annotationPatch = append(annotationPatch, []jsonpatch.Operation{
+					internal.RemoveOp("/metadata/annotations/" + internal.EscapeJSONPointer(annotation)),
+				}...)
 			}
 			delete(pod.Annotations, annotation)
 		}


### PR DESCRIPTION
With this PR the `vault.hashicorp.com/` annotations are always being removed, even if the same annotation is present with `openbao.org/`. This could benefit to remove confusion which annotation is being used.

Also it adds some tests for this feature and #21 