### PR TITLE
Add default seccompProfile of RuntimeDefault for sidecars

### DIFF
--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -242,5 +242,6 @@ func (a *Agent) securityContext() *corev1.SecurityContext {
 			Drop: []corev1.Capability{DefaultAgentDropCapabilities},
 		},
 		AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
+		SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}
 }

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -900,6 +900,9 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
 				},
 				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 		},
 		{
@@ -927,6 +930,9 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
 				},
 				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 		},
 		{
@@ -954,6 +960,9 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
 				},
 				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 		},
 		{
@@ -981,6 +990,9 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
 				},
 				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 		},
 		{
@@ -1008,6 +1020,9 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
 				},
 				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 		},
 		{
@@ -1049,6 +1064,9 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
 				},
 				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 		},
 		{
@@ -1093,6 +1111,9 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
 				},
 				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 		},
 		{
@@ -1121,6 +1142,9 @@ func TestContainerSidecarSecurityContext(t *testing.T) {
 					Drop: []corev1.Capability{DefaultAgentDropCapabilities},
 				},
 				AllowPrivilegeEscalation: pointerutil.BoolPtr(DefaultAgentAllowPrivilegeEscalation),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 		},
 	}
@@ -1316,6 +1340,9 @@ func TestAgentJsonPatch(t *testing.T) {
 			RunAsNonRoot:             optional[bool](true),
 			ReadOnlyRootFilesystem:   optional[bool](true),
 			AllowPrivilegeEscalation: optional[bool](false),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
 		},
 	}
 


### PR DESCRIPTION
Pod Security Standards enforce a seccompProfile. I think it makes sense to set this on default rather than requiring each Pod to set it via the JSON patch annoation.