### PR TITLE
Update webhook CA bundle verification log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
 
 Changes:
 * Refactor environment variables and flags [GH-12](https://github.com/openbao/openbao-k8s/pull/12)
+* Update webhook CA bundle verification log message [GH-93](https://github.com/openbao/openbao-k8s/pull/93)
 * Dependency updates:
   * RedHat UBI container image `ubi8/ubi-minimal` v8.9-1161 => `ubi9-minimal` v9.6-1751286687
   * `github.com/Masterminds/semver/v3` v3.1.1 => v3.4.0

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -378,7 +378,7 @@ func (c *Command) certWatcher(ctx context.Context, ch <-chan cert.Bundle, client
 
 		case <-webhooksWatcher:
 			// Webhooks changed, make sure the CA bundle is up-to-date.
-			log.Info("Webhooks changed. Updating certs...")
+			log.Debug("Checking to ensure CA bundle is up-to-date...")
 
 		case <-ctx.Done():
 			// Quit


### PR DESCRIPTION
Makes log message more accurate by clarifying that this step verifies the existing CA bundle configuration rather than suggesting certificate regeneration.

Changes:

- Adjusted log level from Info to Debug
- Updated message to better reflect the actual operation

---
cherry-pick from vault-k8s PR [#739](https://github.com/hashicorp/vault-k8s/pull/739)