### PR TITLE
fix: disable handling update on pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@ Changes:
   * `github.com/josharian/intern` v1.0.0
   * `github.com/mailru/easyjson` v0.7.7
 
+Bugs:
+* Disable handling update on pods [GH-94](https://github.com/openbao/openbao-k8s/pull/94)
+
 ## 1.4.1 (April 8, 2024)
 
 Changes:

--- a/deploy/injector-mutating-webhook.yaml
+++ b/deploy/injector-mutating-webhook.yaml
@@ -22,10 +22,11 @@ webhooks:
         namespace: "openbao"
       caBundle: ""
     rules:
-      - operations: ["CREATE", "UPDATE"]
+      - operations: ["CREATE"]
         apiGroups: [""]
         apiVersions: ["v1"]
-        resources: ["deployments", "jobs", "pods", "statefulsets"]
+        resources: ["pods"]
+        scope: "Namespaced"
     namespaceSelector: {}
     objectSelector:
       matchExpressions:


### PR DESCRIPTION
* fix: only mutate CREATE pods events

* fix: add missing scope for webhook rule

---------

cherry-pick from vault-k8s PR [#619](https://github.com/hashicorp/vault-k8s/pull/619)