### PR TITLE
feat: add agent injector telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Features:
 * Add support for `openbao.org/` annotations [GH-14](https://github.com/openbao/openbao-k8s/pull/14)
 * Rewrite `vault.hashicorp.com/` annotations to `openbao.org/` annotations [GH-21](https://github.com/openbao/openbao-k8s/pull/21)
 * Add flag to disable rewriting `vault.hashicorp.com/` annotations [GH-23](https://github.com/openbao/openbao-k8s/pull/23)
+* Add agent injector telemetry [GH-96](https://github.com/openbao/openbao-k8s/pull/96)
 
 Changes:
 * Refactor environment variables and flags [GH-12](https://github.com/openbao/openbao-k8s/pull/12)

--- a/agent-inject/handler.go
+++ b/agent-inject/handler.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/hashicorp/go-hclog"
@@ -88,6 +89,14 @@ type Handler struct {
 func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 	h.Log.Info("Request received", "Method", r.Method, "URL", r.URL)
 
+	// Measure request processing duration and monitor request queue
+	requestQueue.Inc()
+	requestStart := time.Now()
+	defer func() {
+		requestProcessingTime.Observe(float64(time.Since(requestStart).Milliseconds()))
+		requestQueue.Dec()
+	}()
+
 	if ct := r.Header.Get("Content-Type"); ct != "application/json" {
 		msg := fmt.Sprintf("Invalid content-type: %q", ct)
 		http.Error(w, msg, http.StatusBadRequest)
@@ -112,7 +121,10 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var admResp admissionv1.AdmissionReview
+	var (
+		mutateResp MutateResponse
+		admResp    admissionv1.AdmissionReview
+	)
 
 	// Both v1 and v1beta1 AdmissionReview types are exactly the same, so the v1beta1 type can
 	// be decoded into the v1 type. However the runtime codec's decoder guesses which type to
@@ -129,7 +141,8 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 		h.Log.Error("error on request", "Error", msg, "Code", http.StatusInternalServerError)
 		return
 	} else {
-		admResp.Response = h.Mutate(admReq.Request)
+		mutateResp = h.Mutate(admReq.Request)
+		admResp.Response = mutateResp.Resp
 	}
 
 	// Default to a v1 AdmissionReview, otherwise the API server may not recognize the request
@@ -145,26 +158,43 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 		msg := fmt.Sprintf("error marshalling admission response: %s", err)
 		http.Error(w, msg, http.StatusInternalServerError)
 		h.Log.Error("error on request", "Error", msg, "Code", http.StatusInternalServerError)
+		incrementInjectionFailures(admReq.Request.Namespace)
 		return
 	}
 
 	if _, err := w.Write(resp); err != nil {
 		h.Log.Error("error writing response", "Error", err)
+		incrementInjectionFailures(admReq.Request.Namespace)
+		return
 	}
+
+	if admResp.Response.Allowed {
+		incrementInjections(admReq.Request.Namespace, mutateResp)
+	} else {
+		incrementInjectionFailures(admReq.Request.Namespace)
+	}
+}
+
+type MutateResponse struct {
+	Resp            *admissionv1.AdmissionResponse
+	InjectedInit    bool
+	InjectedSidecar bool
 }
 
 // Mutate takes an admission request and performs mutation if necessary,
 // returning the final API response.
-func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) MutateResponse {
 	// Decode the pod from the request
 	var pod corev1.Pod
 	if err := json.Unmarshal(req.Object.Raw, &pod); err != nil {
 		h.Log.Error("could not unmarshal request to pod: %s", err)
 		h.Log.Debug("%s", req.Object.Raw)
-		return &admissionv1.AdmissionResponse{
-			UID: req.UID,
-			Result: &metav1.Status{
-				Message: err.Error(),
+		return MutateResponse{
+			Resp: &admissionv1.AdmissionResponse{
+				UID: req.UID,
+				Result: &metav1.Status{
+					Message: err.Error(),
+				},
 			},
 		}
 	}
@@ -207,7 +237,9 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) *admissionv1.Admissi
 		err := fmt.Errorf("error checking if should inject agent: %s", err)
 		return admissionError(req.UID, err)
 	} else if !inject {
-		return resp
+		return MutateResponse{
+			Resp: resp,
+		}
 	}
 
 	h.Log.Debug("checking namespaces..")
@@ -278,14 +310,20 @@ func (h *Handler) Mutate(req *admissionv1.AdmissionRequest) *admissionv1.Admissi
 	patchType := admissionv1.PatchTypeJSONPatch
 	resp.PatchType = &patchType
 
-	return resp
+	return MutateResponse{
+		Resp:            resp,
+		InjectedInit:    agentSidecar.PrePopulate,
+		InjectedSidecar: !agentSidecar.PrePopulateOnly,
+	}
 }
 
-func admissionError(UID types.UID, err error) *admissionv1.AdmissionResponse {
-	return &admissionv1.AdmissionResponse{
-		UID: UID,
-		Result: &metav1.Status{
-			Message: err.Error(),
+func admissionError(UID types.UID, err error) MutateResponse {
+	return MutateResponse{
+		Resp: &admissionv1.AdmissionResponse{
+			UID: UID,
+			Result: &metav1.Status{
+				Message: err.Error(),
+			},
 		},
 	}
 }

--- a/agent-inject/handler_test.go
+++ b/agent-inject/handler_test.go
@@ -522,7 +522,7 @@ func TestHandlerHandle(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			req := require.New(t)
-			resp := tt.Handler.Mutate(&tt.Req)
+			resp := (tt.Handler.Mutate(&tt.Req)).Resp
 			if (tt.Err == "") != resp.Allowed {
 				t.Fatalf("allowed: %v, expected err: %v", resp.Allowed, tt.Err)
 			}

--- a/agent-inject/metrics.go
+++ b/agent-inject/metrics.go
@@ -49,6 +49,10 @@ var (
 )
 
 func incrementInjections(namespace string, res MutateResponse) {
+	if !res.InjectedInit && !res.InjectedSidecar {
+		return
+	}
+
 	// Injection type can be one of: init_and_sidecar (default); init_only; or sidecar_only
 	typeLabel := metricsLabelTypeBoth
 	if res.InjectedInit && !res.InjectedSidecar {

--- a/agent-inject/metrics.go
+++ b/agent-inject/metrics.go
@@ -1,0 +1,77 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package agent_inject
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsNamespace            = "vault"
+	metricsSubsystem            = "agent_injector"
+	metricsLabelNamespace       = "namespace"
+	metricsLabelType            = "injection_type"
+	metricsLabelTypeBoth        = "init_and_sidecar"
+	metricsLabelTypeInitOnly    = "init_only"
+	metricsLabelTypeSidecarOnly = "sidecar_only"
+)
+
+var (
+	requestQueue = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "request_queue_length",
+		Help:      "Count of webhook requests in the injector's queue",
+	})
+
+	requestProcessingTime = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "request_processing_duration_ms",
+		Help:      "Webhook request processing times in milliseconds",
+		Buckets:   []float64{5, 10, 25, 50, 75, 100, 250, 500, 1000, 2500, 5000, 7500, 10000},
+	})
+
+	injectionsByNamespace = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "injections_by_namespace_total",
+		Help:      "Total count of Agent Sidecar injections by namespace",
+	}, []string{metricsLabelNamespace, metricsLabelType})
+
+	failedInjectionsByNamespace = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "failed_injections_by_namespace_total",
+		Help:      "Total count of failed Agent Sidecar injections by namespace",
+	}, []string{metricsLabelNamespace})
+)
+
+func incrementInjections(namespace string, res MutateResponse) {
+	// Injection type can be one of: init_and_sidecar (default); init_only; or sidecar_only
+	typeLabel := metricsLabelTypeBoth
+	if res.InjectedInit && !res.InjectedSidecar {
+		typeLabel = metricsLabelTypeInitOnly
+	} else if res.InjectedSidecar && !res.InjectedInit {
+		typeLabel = metricsLabelTypeSidecarOnly
+	}
+
+	injectionsByNamespace.With(prometheus.Labels{
+		metricsLabelNamespace: namespace,
+		metricsLabelType:      typeLabel,
+	}).Inc()
+}
+
+func incrementInjectionFailures(namespace string) {
+	failedInjectionsByNamespace.With(prometheus.Labels{metricsLabelNamespace: namespace}).Inc()
+}
+
+func MustRegisterInjectorMetrics(registry prometheus.Registerer) {
+	registry.MustRegister(
+		requestQueue,
+		requestProcessingTime,
+		injectionsByNamespace,
+		failedInjectionsByNamespace,
+	)
+}

--- a/agent-inject/metrics_test.go
+++ b/agent-inject/metrics_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package agent_inject
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_incrementInjections(t *testing.T) {
+	MustRegisterInjectorMetrics(prometheus.DefaultRegisterer)
+
+	tests := map[string]struct {
+		namespace      string
+		mutateResponse MutateResponse
+		expectedLabels map[string]string
+	}{
+		"init_only": {
+			namespace: "init",
+			mutateResponse: MutateResponse{
+				InjectedInit:    true,
+				InjectedSidecar: false,
+			},
+			expectedLabels: map[string]string{
+				metricsLabelNamespace: "init",
+				metricsLabelType:      metricsLabelTypeInitOnly,
+			},
+		},
+		"sidecar_only": {
+			namespace: "sidecar",
+			mutateResponse: MutateResponse{
+				InjectedInit:    false,
+				InjectedSidecar: true,
+			},
+			expectedLabels: map[string]string{
+				metricsLabelNamespace: "sidecar",
+				metricsLabelType:      metricsLabelTypeSidecarOnly,
+			},
+		},
+		"init_and_sidecar": {
+			namespace: "both",
+			mutateResponse: MutateResponse{
+				InjectedInit:    true,
+				InjectedSidecar: true,
+			},
+			expectedLabels: map[string]string{
+				metricsLabelNamespace: "both",
+				metricsLabelType:      metricsLabelTypeBoth,
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Cleanup(func() {
+				injectionsByNamespace.Reset()
+			})
+			incrementInjections(test.namespace, test.mutateResponse)
+			assert.Equal(t, 1, testutil.CollectAndCount(injectionsByNamespace))
+			check := injectionsByNamespace.With(prometheus.Labels(test.expectedLabels))
+			assert.Equal(t, float64(1), testutil.ToFloat64(check))
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/subcommand/injector/command.go
+++ b/subcommand/injector/command.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openbao/openbao-k8s/helper/cert"
 	"github.com/openbao/openbao-k8s/leader"
 	"github.com/openbao/openbao-k8s/version"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	adminv1 "k8s.io/api/admissionregistration/v1"
 	adminv1beta "k8s.io/api/admissionregistration/v1beta1"
@@ -233,6 +234,7 @@ func (c *Command) Run(args []string) int {
 
 	// Registering path to expose metrics
 	if c.flagTelemetryPath != "" {
+		agentInject.MustRegisterInjectorMetrics(prometheus.DefaultRegisterer)
 		c.UI.Info(fmt.Sprintf("Registering telemetry path on %q", c.flagTelemetryPath))
 		mux.Handle(c.flagTelemetryPath, promhttp.Handler())
 	}


### PR DESCRIPTION
* feat: add agent injector telemetry

Add Prometheus metrics to monitor the Agent Injector's performance. New metrics include a gauge of current requests being processed by the webhook, a summary of request processing times, and a count of successful and failed injections by Kubernetes namespace.

Successful injections are broken down by injection type. The `injection_type` label can assume the value `init_only` for injections with only an initContainer (no sidecar) and `sidecar` for all other cases (sidecar only or sidecar + initContainer).

Fixes AG-005161.

* refactor(metrics): add metadata to mutate response

Update the `Mutate()` method to return a struct that extends the existing return data (AdmissionResponse) with metadata on the types of Vault Agent injections made. The metadata informs the count of injections by namespace, which are now further broken down by type of injection.

---
cherry-pick from vault-k8s PR [#703](https://github.com/hashicorp/vault-k8s/pull/703) and [#709](https://github.com/hashicorp/vault-k8s/pull/709) and [#716](https://github.com/hashicorp/vault-k8s/pull/716)